### PR TITLE
Bump the minor-and-patch-dependencies group with 2 updates

### DIFF
--- a/coffeeshop-application/build.gradle
+++ b/coffeeshop-application/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.12.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.0'
     testImplementation 'org.assertj:assertj-core:3.27.3'
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/coffeeshop-infrastructure/build.gradle
+++ b/coffeeshop-infrastructure/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-library'
     id 'jvm-test-suite'
-    id 'org.springframework.boot' version '3.4.6'
+    id 'org.springframework.boot' version '3.5.0'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 


### PR DESCRIPTION
Bumps the minor-and-patch-dependencies group with 2 updates: [org.junit.jupiter:junit-jupiter](https://github.com/junit-team/junit5) and [org.springframework.boot](https://github.com/spring-projects/spring-boot).


Updates `org.junit.jupiter:junit-jupiter` from 5.12.2 to 5.13.0
- [Release notes](https://github.com/junit-team/junit5/releases)
- [Commits](https://github.com/junit-team/junit5/compare/r5.12.2...r5.13.0)

Updates `org.springframework.boot` from 3.4.6 to 3.5.0
- [Release notes](https://github.com/spring-projects/spring-boot/releases)
- [Commits](https://github.com/spring-projects/spring-boot/compare/v3.4.6...v3.5.0)

---
updated-dependencies:
- dependency-name: org.junit.jupiter:junit-jupiter dependency-version: 5.13.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: minor-and-patch-dependencies
- dependency-name: org.springframework.boot dependency-version: 3.5.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: minor-and-patch-dependencies ...